### PR TITLE
Fix PYTHONPATH export bug in startup script

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1,2 +1,2 @@
-export PYTHONPATH=./web/:$PYTHONPATH~
+export PYTHONPATH=./web/:$PYTHONPATH
 gunicorn --bind 0.0.0.0:8080 web.app:app


### PR DESCRIPTION
## Summary
- fix typo in `main.sh` that appended `~` to `$PYTHONPATH`

## Testing
- `python -m py_compile web/*.py`